### PR TITLE
feat: add AddRecipeImage with validation and adaptive preview

### DIFF
--- a/src/components/AddReceipImage/AddRecipeImage.jsx
+++ b/src/components/AddReceipImage/AddRecipeImage.jsx
@@ -1,0 +1,81 @@
+import React, { useState, useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import styles from "./AddRecipeImage.module.css";
+
+const AddRecipeImage = () => {
+  const {
+    register,
+    setValue,
+    formState: { errors },
+  } = useFormContext();
+
+  const [previewUrl, setPreviewUrl] = useState(null);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const handlePhotoChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const isValidType = ["image/jpeg", "image/jpg", "image/png"].includes(
+      file.type
+    );
+    const isValidSize = file.size <= 10 * 1024 * 1024;
+
+    setValue("photo", file, { shouldValidate: true });
+
+    if (isValidType && isValidSize) {
+      setPreviewUrl(URL.createObjectURL(file));
+    } else {
+      setPreviewUrl(null);
+    }
+
+    e.target.value = null;
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div
+        className={`${styles.photoUpload} ${previewUrl ? styles.filled : ""}`}
+      >
+        {previewUrl ? (
+          <img
+            src={previewUrl}
+            alt="Preview of uploaded recipe image"
+            className={styles.preview}
+          />
+        ) : (
+          <label htmlFor="photo-upload" className={styles.labelWrapper}>
+            <svg className={styles.icon}>
+              <use href="/src/assets/sprite.svg#icon-camera" />
+            </svg>
+            <span className={styles.uploadText}>Upload a photo</span>
+          </label>
+        )}
+
+        <input
+          id="photo-upload"
+          type="file"
+          accept="image/*"
+          {...register("photo")}
+          onChange={handlePhotoChange}
+          className={styles.fileInput}
+        />
+      </div>
+
+      {previewUrl && (
+        <label htmlFor="photo-upload" className={styles.reupload}>
+          Upload another photo
+        </label>
+      )}
+
+      {errors?.photo && <p className={styles.error}>{errors.photo.message}</p>}
+    </div>
+  );
+};
+
+export default AddRecipeImage;

--- a/src/components/AddReceipImage/AddRecipeImage.module.css
+++ b/src/components/AddReceipImage/AddRecipeImage.module.css
@@ -1,0 +1,71 @@
+.photoUpload {
+  border: 1px dashed #BFBEBE;
+  border-radius: 30px;
+  width: 100%;
+  height: 318px;
+  aspect-ratio: 343 / 318;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.filled {
+  border: none;
+  height: auto;
+}
+
+.labelWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  width: 100%;
+}
+
+.uploadText {
+  text-decoration: underline;
+}
+
+.fileInput {
+  display: none;
+}
+
+.icon {
+  width: 50px;
+  height: 50px;
+  fill: #bfbebe;
+  margin-bottom: 8px;
+}
+
+@media screen and (min-width: 768px) {
+  .photoUpload {
+    width: 704px;
+    height: 400px;
+    aspect-ratio: 704 / 400;
+    margin-bottom: 20px;
+  }
+
+  .icon {
+    width: 64px;
+    height: 64px;
+    margin-bottom: 16px;
+  }
+}
+
+@media screen and (min-width: 1440px) {
+  .photoUpload {
+    max-width: 551px;
+    aspect-ratio: 551 / 400;
+    margin-bottom: 20px;
+  }
+
+  .icon {
+    width: 64px;
+    height: 64px;
+    margin-bottom: 16px;
+  }
+}

--- a/src/components/AddRecipeForm/AddRecipeForm.jsx
+++ b/src/components/AddRecipeForm/AddRecipeForm.jsx
@@ -4,6 +4,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import styles from "./AddRecipeForm.module.css";
 import AddRecipeImage from "../AddReceipImage/AddRecipeImage";
 import { recipeSchema } from "./validationSchema";
+import Button from "../Button/Button";
 
 const AddRecipeForm = () => {
   const methods = useForm({
@@ -22,7 +23,7 @@ const AddRecipeForm = () => {
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <AddRecipeImage />
-          <button type="submit">Submit</button>
+          <Button type="submit">Publish</Button>
         </form>
       </FormProvider>
     </div>

--- a/src/components/AddRecipeForm/AddRecipeForm.jsx
+++ b/src/components/AddRecipeForm/AddRecipeForm.jsx
@@ -1,12 +1,30 @@
 import React from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
 import styles from "./AddRecipeForm.module.css";
+import AddRecipeImage from "../AddReceipImage/AddRecipeImage";
+import { recipeSchema } from "./validationSchema";
 
 const AddRecipeForm = () => {
+  const methods = useForm({
+    resolver: yupResolver(recipeSchema),
+    mode: "onChange",
+  });
+
+  const { handleSubmit } = methods;
+
+  const onSubmit = (data) => {
+    console.log("Form submitted", data);
+  };
+
   return (
     <div className={styles.addRecipeForm}>
-      <div className={styles.photoUpload}>
-        <span className={styles.uploadText}>Upload a photo</span>
-      </div>
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <AddRecipeImage />
+          <button type="submit">Submit</button>
+        </form>
+      </FormProvider>
     </div>
   );
 };

--- a/src/components/AddRecipeForm/AddRecipeForm.module.css
+++ b/src/components/AddRecipeForm/AddRecipeForm.module.css
@@ -1,21 +1,11 @@
 .addRecipeForm {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-  }
+  display: flex;
+  width: 100%;
+  text-align: center;
+}
 
-.photoUpload {
-    border: 1px dashed #BFBEBE;
-    border-radius: 30px;
-    width: 551px;
-    height: 400px;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+@media screen and (min-width: 1440px) {
+  .addRecipeForm {
+    flex-direction: row;
   }
-  
-  .uploadText {
-    text-decoration: underline;
-  }
+}

--- a/src/components/AddRecipeForm/validationSchema.js
+++ b/src/components/AddRecipeForm/validationSchema.js
@@ -1,0 +1,15 @@
+import * as yup from "yup";
+
+export const recipeSchema = yup.object().shape({
+  photo: yup
+    .mixed()
+    .required("Photo is required")
+    .test("fileSize", "Max file size is 10MB", (file) => {
+      return file && file.size <= 10 * 1024 * 1024;
+    })
+    .test("fileType", "Unsupported format. Use JPG/PNG.", (file) => {
+      return (
+        file && ["image/jpeg", "image/jpg", "image/png"].includes(file.type)
+      );
+    }),
+});


### PR DESCRIPTION
What’s done:
- Added AddRecipeImage component for recipe image upload:
implements image preview via URL.createObjectURL;
uses a hidden <input type="file" /> wrapped in a clickable label;
allows re-uploading the same file (e.target.value = null).

- Validation schema extracted to a separate validationSchema.js file:
photo is required;
allowed file types: jpg, jpeg, png;
max file size: 10MB.

- Manual validation of file type and size inside handlePhotoChange to prevent preview of invalid files.

- Refactored AddRecipeForm:

- wrapped with FormProvider;

Yup schema connected via yupResolver.