### PR TITLE
feat(recipe-form): handle backend error with toast, reset form only o…

### DIFF
--- a/src/components/AddRecipeForm/AddRecipeForm.module.css
+++ b/src/components/AddRecipeForm/AddRecipeForm.module.css
@@ -8,7 +8,6 @@
 .formAdd {
   display: flex;
   flex-direction: column;
-  gap: 80px;
 }
 
 .fieldsGroup {
@@ -191,18 +190,101 @@ textarea:focus {
 }
 
 @media screen and (min-width: 768px) {
+  .formGroup >.formCategory, 
+  .formGroup >.formCookingtime, 
+  .formGroup > .formIngredients, 
+  .formGroup > .formQuantity,
+  .formGroup > .formArea {
+    margin-bottom: 0;
+  }
+
+  .formGroup {
+    margin-bottom: 40px;
+  }
+
+  .descriptionWrapper, .formQuantity, .textareaWrapper {
+    min-height: 40px;
+  }
+
+  .formGroup.formDescription, 
+  .formGroup.formCategoryCookingtime, 
+  .formGroup.formGroupArea {
+    margin-bottom: 60px;
+  }
+
+  .formGroup.formIngredientsQuantity {
+    margin-bottom: 40px;
+  }
+
+  .formGroup.formCategoryCookingtime, .formGroup.formIngredientsQuantity {
+    flex-direction: row;
+    gap: 19px;
+  }
+
+  .formGroup.formIngredientsQuantity {
+    align-items: end;
+  }
+
+  .formCategory,
+  .formArea,
+  .formCookingtime,
+  .formIngredients,
+  .formQuantity {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 315px;
+  }
+
   .addRecipeForm {
     flex-direction: row;
+  }
+
+  .formGroup.formRecipePreparation {
+    margin-top: 40px;
+  }
+
+  .formGroup.formRecipePreparation {
+    margin-bottom: 80px;
+  }
+
+  .textareaWrapper {
+    margin-top: 40px;
+  }
+  
+  .formGroup.formGroupSubmit {
+    margin-bottom: 0;
   }
 }
 
 @media screen and (min-width: 1440px) {
   .formAdd {
     flex-direction: row;
+    gap: 80px;
+  }
+
+  .wrapper {
+    margin-bottom: 0;
+  }
+
+  .titleInput {
+    font-size: 24px;
   }
 
   .formGroup {
     width: 649px;
+  }
+
+  .category,
+  .area,
+  .cookingtime,
+  .ingredients,
+  .titleRecipePreparation,
+  .formGroup > label {
+    font-size: 20px;
+  }
+  .description, .recipePreparation, .quantity{
+    font-size: 16px;
   }
 
   .formCategoryCookingtime {

--- a/src/components/AddRecipeImage/AddRecipeImage.module.css
+++ b/src/components/AddRecipeImage/AddRecipeImage.module.css
@@ -1,5 +1,5 @@
 .wrapper{
-  margin-bottom: 32px;
+  margin-bottom: 80px;
 }
 .photoUpload {
   position: relative;
@@ -13,7 +13,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-bottom: 16px;
   contain: content;
 }
 

--- a/src/redux/addRecipe/actions.js
+++ b/src/redux/addRecipe/actions.js
@@ -9,6 +9,8 @@ export const fetchRecipeThunk = createAsyncThunk("addRecipe/submit", async (form
     });
     return data;
   } catch (error) {
-    return thunkAPI.rejectWithValue(error.response?.data || error.message);
+    return thunkAPI.rejectWithValue(
+      error.response?.data?.message || error.message || "Unknown error",
+    );
   }
 });

--- a/src/redux/addRecipe/selectors.js
+++ b/src/redux/addRecipe/selectors.js
@@ -1,2 +1,3 @@
 export const selectAddRecipeSuccess = (state) => state.addRecipe.success;
 export const selectCreatedRecipeId = (state) => state.addRecipe.recipeId;
+export const selectAddRecipeError = (state) => state.addRecipe.error;

--- a/src/redux/addRecipe/slice.js
+++ b/src/redux/addRecipe/slice.js
@@ -15,6 +15,9 @@ const addRecipeSlice = createSlice({
       state.success = false;
       state.recipeId = null;
     },
+    clearError: (state) => {
+      state.error = null;
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -37,4 +40,5 @@ const addRecipeSlice = createSlice({
 });
 
 export const { clearSuccess } = addRecipeSlice.actions;
+export const { clearError } = addRecipeSlice.actions;
 export const addRecipeReducer = addRecipeSlice.reducer;


### PR DESCRIPTION
- Added error handling from the backend: toast displays the message from Redux error
- The form is now reset only on successful submission (recipeCreated)
- useEffect is supplemented with logic for handling both success and error
- Redux slice and selectors are supplemented with error handling (error + clearError)
- Form styles are brought to a single style using clsx