### PR TITLE
make the ingredient selection field not required

### DIFF
--- a/src/components/AddRecipeForm/validationSchema.js
+++ b/src/components/AddRecipeForm/validationSchema.js
@@ -25,11 +25,6 @@ export const recipeSchema = yup.object().shape({
 
   area: yup.number().typeError("Area is required").required("Area is required"),
 
-  ingredients: yup
-    .number()
-    .typeError("Ingredients is required")
-    .required("Ingredients is required"),
-
   cookingTime: yup
     .number()
     .typeError("Cooking time is required")


### PR DESCRIPTION
We remove the "ingredients" field from the validation scheme. We check the id in the list of ingredients.